### PR TITLE
style: add global stylesheet

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,30 @@
+// 1) Год в футере
+document.addEventListener('DOMContentLoaded', () => {
+  const yearEl = document.getElementById('mo-year');
+  if (yearEl) yearEl.textContent = new Date().getFullYear();
+});
+
+// 2) Mailto без бэкенда
+function moSendMail(e) {
+  e.preventDefault();
+
+  const nomEl = document.getElementById('mo-nom');
+  const emailEl = document.getElementById('mo-email');
+  const msgEl = document.getElementById('mo-msg');
+
+  const nom = (nomEl?.value || '').trim();
+  const email = (emailEl?.value || '').trim();
+  const msg = (msgEl?.value || '').trim();
+
+  const subject = `[Site RSE] Message de ${nom || 'Client'}`;
+  const body =
+    `Nom: ${nom}\n` +
+    `Email: ${email}\n\n` +
+    `${msg}`;
+
+  const href = `mailto:contact@ostanin-rse.fr?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+  window.location.href = href;
+
+  const ok = document.getElementById('mo-ok');
+  if (ok) ok.hidden = false;
+}

--- a/index.html
+++ b/index.html
@@ -1,242 +1,183 @@
 <!doctype html>
 <html lang="fr">
 <head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Mikhail Ostanin — Consultant RSE</title>
-<meta name="description" content="Conseil RSE, bilans carbone, reporting, ateliers et conformité. Basé au Mans, interventions FR.">
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;800&display=swap" rel="stylesheet">
-<style>
-  :root{
-    --ink:#0e0e0e; --muted:#5f6b76; --line:#e9edf2;
-    --accent:#5D2DE6; --accent2:#0a6cc2;
-    --radius:18px; --shadow:0 10px 30px rgba(0,0,0,.10);
-    --maxw:1120px;
-  }
-  *{box-sizing:border-box}
-  html,body{
-    margin:0; color:var(--ink); font-family:Inter,system-ui,Arial,sans-serif;
-    /* мягкий фон + узор */
-    background:
-      radial-gradient(1400px 900px at 15% -10%, #fff7f0 0,#f1f6ff 40%, #ffffff 80%),
-      repeating-conic-gradient(from 0deg at 40% 30%, rgba(0,0,0,.02) 0 12deg, transparent 12deg 24deg);
-    background-attachment: fixed;
-  }
-  a{color:inherit;text-decoration:none}
-  .wrap{max-width:var(--maxw);margin:0 auto;padding:22px}
-  header{position:sticky;top:0;backdrop-filter:blur(10px);background:rgba(255,255,255,.65);border-bottom:1px solid var(--line);z-index:20}
-  .nav{display:flex;align-items:center;justify-content:space-between;padding:10px 0}
-  .brand{display:flex;gap:12px;align-items:center;font-weight:800}
-  .logo{width:36px;height:36px;border-radius:10px;background:
-    radial-gradient(120px 120px at 20% 20%, #9E81F0, #7241FF 60%),
-    linear-gradient(45deg,#6bdcff,#e6d8ff);box-shadow:var(--shadow);animation:float 6s ease-in-out infinite}
-  .navlinks a{margin-left:18px;color:#39424a;opacity:.9}
-  .btn{display:inline-block;padding:12px 18px;border-radius:999px;font-weight:700;transition:.15s transform, .2s box-shadow}
-  .btn:hover{transform:translateY(-2px)}
-  .btn-primary{background:linear-gradient(135deg,var(--accent),var(--accent2));color:#fff;box-shadow:var(--shadow)}
-  .btn-ghost{border:1px solid var(--line);background:#fff}
-
-  /* HERO — текст + портрет + декор */
-  .hero{padding:68px 0 40px;border-bottom:1px solid var(--line);position:relative;overflow:hidden}
-  .hero-grid{display:grid;grid-template-columns:1.1fr .9fr;gap:32px;align-items:center}
-  .kicker{color:var(--accent);font-weight:800;letter-spacing:.06em;text-transform:uppercase;font-size:.8rem}
-  h1{font-size:clamp(30px,4.3vw,52px);line-height:1.08;margin:.3em 0}
-  .lead{color:var(--muted);font-size:1.08rem;max-width:62ch}
-  .hero-card{position:relative}
-  .blob{
-    position:absolute;inset:-40px -30px auto auto;width:360px;height:360px;filter:blur(40px);opacity:.45;z-index:-1;
-    background:radial-gradient(closest-side, #8fb7ff 0%, transparent 70%),
-               radial-gradient(closest-side, #b79bff 0%, transparent 70%),
-               radial-gradient(closest-side, #8ffff0 0%, transparent 70%);
-    mix-blend-mode:multiply;border-radius:50%;
-    animation:blob 12s ease-in-out infinite alternate;
-  }
-  .portrait{
-    width:260px;height:260px;border-radius:50%;overflow:hidden;border:8px solid #fff;box-shadow:var(--shadow);margin:0 auto;
-    transform:translateZ(0);transition:transform .3s ease
-  }
-  .portrait:hover{transform:scale(1.02)}
-  .hero-card .tag{
-    position:absolute;bottom:-10px;left:50%;transform:translateX(-50%);
-    background:#fff;border:1px solid var(--line);border-radius:999px;padding:8px 12px;box-shadow:var(--shadow);font-weight:700
-  }
-
-  /* SECTION base */
-  section{padding:56px 0;border-bottom:1px solid var(--line)}
-  h2{font-size:clamp(22px,3.2vw,34px);margin:0 0 12px}
-  .card{background:#fff;border:1px solid var(--line);border-radius:var(--radius);box-shadow:var(--shadow)}
-  .grid{display:grid;gap:18px}
-
-  /* MISSION — изображение слева, текст справа */
-  .mission{display:grid;grid-template-columns:1fr 1fr;gap:28px;align-items:center}
-  .img-frame{border-radius:20px;overflow:hidden;border:1px solid var(--line);box-shadow:var(--shadow);
-             transform:translateY(16px) scale(.98);opacity:0;transition:.8s transform,.8s opacity}
-  .img-frame img{width:100%;height:100%;object-fit:cover;display:block}
-  .reveal{transform:translateY(0) scale(1);opacity:1}
-  .muted{color:var(--muted)}
-
-  /* COLLAB — крупный фон справа, текст слева */
-  .collab{display:grid;grid-template-columns:1.05fr .95fr;gap:0;align-items:stretch;border-radius:22px;overflow:hidden}
-  .collab .text{padding:28px}
-  .collab .visual{position:relative;min-height:360px}
-  .collab .visual img{position:absolute;inset:0;width:100%;height:100%;object-fit:cover}
-  .overlay{position:absolute;inset:0;background:linear-gradient(90deg, rgba(0,0,0,.35), rgba(0,0,0,.15));}
-  .collab .text h3{margin:.4rem 0}
-  .collab .text p{color:var(--muted)}
-  .pill{display:inline-block;margin-top:10px;background:#fff;border:1px solid var(--line);border-radius:999px;padding:8px 12px;font-weight:700}
-
-  /* SERVICES компактно */
-  .grid-3{grid-template-columns:repeat(3,1fr)}
-  .service{padding:18px}
-  .service h3{margin:.2rem 0}
-  .service p{color:var(--muted)}
-
-  footer{padding:28px 0;color:#6b757f}
-  .split{display:flex;flex-wrap:wrap;gap:14px}
-  .split>*{flex:1 1 280px}
-
-  @media (max-width:980px){.hero-grid,.mission,.collab{grid-template-columns:1fr}.collab{border-radius:18px}}
-  @keyframes float{0%,100%{transform:translateY(0)}50%{transform:translateY(-4px)}}
-  @keyframes blob{0%{transform:translate(0,0) scale(1)}100%{transform:translate(-20px,10px) scale(1.08)}}
-</style>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Mikhail Ostanin — Consultant RSE</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;800&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
 </head>
 <body>
-<header>
-  <div class="wrap nav">
-    <a class="brand" href="#top"><div class="logo" aria-hidden="true"></div> Mikhail Ostanin</a>
-    <nav class="navlinks" aria-label="Main">
-      <a href="#services">Services</a>
-      <a href="#mission">Mission</a>
-      <a href="#collab">Collaboration</a>
-      <a href="#contact" class="btn btn-primary">Devis</a>
-    </nav>
-  </div>
+<header class="mo-wrap mo-nav">
+  <a class="mo-brand" href="#top" aria-label="Aller en haut de page">
+    <span class="mo-logo" aria-hidden="true"></span>
+    <span>Mikhail Ostanin</span>
+  </a>
+  <nav class="mo-links" aria-label="Navigation principale">
+    <a href="#services">Services</a>
+    <a href="#mission">Mission</a>
+    <a href="#collab">Collaboration</a>
+    <a href="#contact" class="mo-btn mo-btn-primary">Devis</a>
+  </nav>
 </header>
 
-<main>
+<main id="top">
   <!-- HERO -->
-  <section class="hero">
-    <div class="wrap hero-grid">
+  <section class="mo-hero" aria-labelledby="hero-title">
+    <div class="mo-wrap mo-hero-grid">
       <div>
-        <div class="kicker">RSE • Bilans carbone • Reporting</div>
-        <h1>Résultats mesurables, pédagogie claire — votre transition durable, sans blabla</h1>
-        <p class="lead">J’accompagne PME & écoles sur les <em>bilans GES</em>, <em>reporting</em>, <em>ateliers</em> et la <em>conformité</em>. Approche orientée données, livrables prêts à l’emploi et plan d’actions priorisé.</p>
-        <p style="margin-top:16px">
-          <a class="btn btn-primary" href="#contact">Parler de votre projet</a>
-          <a class="btn btn-ghost" href="#services" style="margin-left:8px">Voir les services</a>
+        <p class="mo-kicker">RSE • Bilans carbone • Reporting</p>
+        <h1 id="hero-title">Résultats mesurables, pédagogie claire — votre transition durable, sans blabla</h1>
+        <p class="mo-lead">
+          J’accompagne PME & écoles sur les <em>bilans GES</em>, <em>reporting</em>, <em>ateliers</em> et la <em>conformité</em>.
+          Approche orientée données, livrables prêts à l’emploi et plan d’actions priorisé.
+        </p>
+        <p>
+          <a class="mo-btn mo-btn-primary" href="#contact">Parler de votre projet</a>
+          <a class="mo-btn mo-btn-ghost" href="#services" style="margin-left:8px">Voir les services</a>
         </p>
       </div>
 
-      <aside class="hero-card">
-        <div class="blob" aria-hidden="true"></div>
-        <figure class="portrait">
-          <!-- ЗАМЕНИ на свой файл портрета -->
-          <img src="me.jpg" alt="Portrait — Mikhail Ostanin" width="260" height="260" style="width:100%;height:100%;object-fit:cover">
+      <aside class="mo-hero-card" aria-label="Portrait du consultant">
+        <div class="mo-blob" aria-hidden="true"></div>
+        <figure class="mo-portrait">
+          <img src="https://ostanin-rse.fr/wp-content/uploads/2025/08/me.jpg"
+               alt="Portrait — Mikhail Ostanin"
+               width="260" height="260"
+               loading="lazy" decoding="async"
+               style="width:100%;height:100%;object-fit:cover">
         </figure>
-        <div class="tag">Consultant RSE • FR | EN | RU</div>
+        <div class="mo-tag" aria-hidden="true">Consultant RSE</div>
       </aside>
     </div>
   </section>
 
-  <!-- MISSION (plant.jpg слева) -->
-  <section id="mission">
-    <div class="wrap mission">
-      <figure class="img-frame will-reveal">
-        <img src="plant.jpg" alt="Jeune plante — symbole de croissance durable" loading="lazy">
+  <!-- MISSION -->
+  <section id="mission" class="mission-section" aria-labelledby="mission-title">
+    <div class="mission-wrap">
+      <figure class="mission-figure">
+        <img
+          src="https://ostanin-rse.fr/wp-content/uploads/2025/08/workshop-scaled.jpg"
+          alt="Jeune plante, symbole d'une croissance durable"
+          loading="lazy" decoding="async"
+          width="960" height="1280">
+        <figcaption class="visually-hidden">Atelier RSE — data, feuille de route, mise en œuvre</figcaption>
       </figure>
-      <div>
-        <h2>Mission</h2>
-        <p class="muted">Une transition durable commence par des gestes concrets et des décisions fondées sur les données. Je structure votre démarche : périmètre, collecte, facteurs d’émission, arbitrages, feuille de route 12–36 mois.</p>
-        <ul class="muted">
-          <li>Bilans carbone (Scopes 1–2–3)</li>
-          <li>Reporting & indicateurs clés</li>
-          <li>Ateliers d’acculturation</li>
-          <li>Gouvernance & suivi</li>
+
+      <div class="mission-content">
+        <span class="mission-kicker">Pourquoi moi</span>
+        <h2 id="mission-title" class="mission-title">Mission</h2>
+
+        <p class="mission-lead">
+          Une transition durable commence par des gestes concrets et des décisions fondées sur les données.
+          Je structure votre démarche : périmètre, collecte, facteurs d’émission, arbitrages, feuille de route 12–36 mois.
+        </p>
+
+        <ul class="mission-list" role="list">
+          <li>
+            <svg class="check" viewBox="0 0 24 24" aria-hidden="true"><path d="M20.3 5.7a1 1 0 0 1 0 1.4l-10 10a1 1 0 0 1-1.4 0l-5-5a1 1 0 1 1 1.4-1.4L10 14.3 18.9 5.7a1 1 0 0 1 1.4 0Z"/></svg>
+            Bilans carbone (Scopes 1–2–3)
+          </li>
+          <li>
+            <svg class="check" viewBox="0 0 24 24" aria-hidden="true"><path d="M20.3 5.7a1 1 0 0 1 0 1.4l-10 10a1 1 0 0 1-1.4 0l-5-5a1 1 0 1 1 1.4-1.4L10 14.3 18.9 5.7a1 1 0 0 1 1.4 0Z"/></svg>
+            Reporting & indicateurs clés
+          </li>
+          <li>
+            <svg class="check" viewBox="0 0 24 24" aria-hidden="true"><path d="M20.3 5.7a1 1 0 0 1 0 1.4l-10 10a1 1 0 0 1-1.4 0l-5-5a1 1 0 1 1 1.4-1.4L10 14.3 18.9 5.7a1 1 0 0 1 1.4 0Z"/></svg>
+            Ateliers d’acculturation
+          </li>
+          <li>
+            <svg class="check" viewBox="0 0 24 24" aria-hidden="true"><path d="M20.3 5.7a1 1 0 0 1 0 1.4l-10 10a1 1 0 0 1-1.4 0l-5-5a1 1 0 1 1 1.4-1.4L10 14.3 18.9 5.7a1 1 0 0 1 1.4 0Z"/></svg>
+            Gouvernance & suivi
+          </li>
         </ul>
       </div>
     </div>
   </section>
 
-  <!-- COLLAB (фон с workshop.jpg справа + текст слева) -->
-  <section id="collab">
-    <div class="wrap">
-      <div class="collab card">
-        <div class="text">
-          <h2>Collaboration</h2>
+  <!-- COLLAB -->
+  <section id="collab" class="mo-section" aria-labelledby="collab-title">
+    <div class="mo-wrap">
+      <div class="mo-collab mo-card">
+        <div class="mo-c-text">
+          <h2 id="collab-title">Collaboration</h2>
           <h3>Construisons ensemble vos projets RSE</h3>
-          <p>Co-design avec vos équipes : ateliers rapides pour prioriser les actions à plus fort impact/coût. Restitutions visuelles, templates réutilisables, calendrier clair.</p>
-          <a class="pill" href="#contact">Découvrir les modalités</a>
+          <p class="mo-muted">
+            Co-design avec vos équipes : ateliers rapides pour prioriser les actions à plus fort impact/coût.
+            Restitutions visuelles, templates réutilisables, calendrier clair.
+          </p>
+          <a class="mo-pill" href="#contact">Découvrir les modalités</a>
         </div>
-        <div class="visual">
-          <img src="workshop.jpg" alt="Groupe en atelier — collaboration sur la durabilité" loading="lazy">
-          <div class="overlay" aria-hidden="true"></div>
+        <div class="mo-c-visual" aria-hidden="true">
+          <img src="https://ostanin-rse.fr/wp-content/uploads/2025/08/workshop-scaled.jpg"
+               alt=""
+               loading="lazy" decoding="async">
+          <div class="mo-overlay"></div>
         </div>
       </div>
     </div>
   </section>
 
   <!-- SERVICES -->
-  <section id="services">
-    <div class="wrap">
-      <h2>Services</h2>
-      <div class="grid grid-3">
-        <article class="card service"><h3>Bilans carbone</h3><p class="muted">Périmètres 1–2–3, calculs, rapport & plan d’actions.</p></article>
-        <article class="card service"><h3>Reporting RSE</h3><p class="muted">KPI, tableaux de bord, matérialité, traçabilité.</p></article>
-        <article class="card service"><h3>Ateliers</h3><p class="muted">Climat, déchets, mobilité, alimentation durable.</p></article>
+  <section id="services" class="mo-section" aria-labelledby="services-title">
+    <div class="mo-wrap">
+      <h2 id="services-title">Services</h2>
+      <div class="mo-grid mo-grid-3">
+        <article class="mo-card mo-service">
+          <h3>Bilans carbone</h3>
+          <p class="mo-muted">Périmètres 1–2–3, calculs, rapport & plan d’actions.</p>
+        </article>
+        <article class="mo-card mo-service">
+          <h3>Reporting RSE</h3>
+          <p class="mo-muted">KPI, tableaux de bord, matérialité, traçabilité.</p>
+        </article>
+        <article class="mo-card mo-service">
+          <h3>Ateliers</h3>
+          <p class="mo-muted">Climat, déchets, mobilité, alimentation durable.</p>
+        </article>
       </div>
     </div>
   </section>
 
   <!-- CONTACT -->
-  <section id="contact">
-    <div class="wrap">
-      <h2>Contact</h2>
-      <div class="grid" style="grid-template-columns:1fr 1fr">
-        <form class="card" onsubmit="sendMail(event)" style="padding:18px">
-          <input id="nom" name="nom" placeholder="Nom" required style="width:100%;padding:12px;border-radius:12px;border:1px solid var(--line);margin-bottom:10px;background:#fff">
-          <input id="email" name="email" type="email" placeholder="E-mail" required style="width:100%;padding:12px;border-radius:12px;border:1px solid var(--line);margin-bottom:10px;background:#fff">
-          <textarea id="message" name="message" rows="6" placeholder="Votre besoin (périmètre, délais, contraintes)…" required style="width:100%;padding:12px;border-radius:12px;border:1px solid var(--line);margin-bottom:10px;background:#fff"></textarea>
-          <button class="btn btn-primary" type="submit">Envoyer</button>
-          <p id="ok" class="muted" style="display:none;margin-top:8px">Merci ! Un e-mail est prêt dans votre client.</p>
+  <section id="contact" class="mo-section" aria-labelledby="contact-title">
+    <div class="mo-wrap">
+      <h2 id="contact-title">Contact</h2>
+      <div class="mo-grid mo-grid-2">
+        <form class="mo-card" onsubmit="moSendMail(event)">
+          <div style="padding:18px;border:0">
+            <label class="visually-hidden" for="mo-nom">Nom</label>
+            <input id="mo-nom" name="nom" placeholder="Nom" required class="mo-input">
+
+            <label class="visually-hidden" for="mo-email">E-mail</label>
+            <input id="mo-email" name="email" type="email" placeholder="E-mail" required class="mo-input">
+
+            <label class="visually-hidden" for="mo-msg">Message</label>
+            <textarea id="mo-msg" name="message" rows="6" placeholder="Votre besoin (périmètre, délais, contraintes)…" required class="mo-input"></textarea>
+
+            <button class="mo-btn mo-btn-primary" type="submit">Envoyer</button>
+            <p id="mo-ok" class="mo-muted" hidden>Merci ! Un e-mail est prêt dans votre client.</p>
+          </div>
         </form>
-        <div class="card" style="padding:18px">
+
+        <div class="mo-card" style="padding:18px">
           <h3>Coordonnées</h3>
           <p><strong>Mikhail Ostanin</strong><br>Consultant RSE & transition durable<br>Le Mans, France</p>
-          <p>Tél : <a href="tel:+33765292978">+33 7 65 29 29 78</a><br>
-             E-mail : <a href="mailto:ostanin.mikhail@gmail.com">ostanin.mikhail@gmail.com</a></p>
-          <p class="muted">Mentions : micro-entreprise (activité libérale). APE provisoire : 7022Z. SIREN : à venir.</p>
+          <p>E-mail : <a href="mailto:contact@ostanin-rse.fr">contact@ostanin-rse.fr</a></p>
+          <p class="mo-muted">Mentions : micro-entreprise (activité libérale). APE provisoire : 7022Z. SIREN : à venir.</p>
         </div>
       </div>
     </div>
   </section>
 </main>
 
-<footer>
-  <div class="wrap split" style="align-items:center">
-    <p>© <span id="year"></span> Mikhail Ostanin — Tous droits réservés.</p>
-    <p class="muted">RGPD : pas de cookies tiers. Les messages passent par votre client mail.</p>
+<footer class="mo-footer" role="contentinfo">
+  <div class="mo-wrap mo-split" style="align-items:center">
+    <p>© <span id="mo-year"></span> Mikhail Ostanin — Tous droits réservés.</p>
+    <p class="mo-muted">RGPD : pas de cookies tiers. Les messages passent par votre client mail.</p>
   </div>
 </footer>
 
-<script>
-  // année dynamique
-  document.getElementById('year').textContent = new Date().getFullYear();
-
-  // mailto
-  function sendMail(e){
-    e.preventDefault();
-    const nom = encodeURIComponent(document.getElementById('nom').value.trim());
-    const email = encodeURIComponent(document.getElementById('email').value.trim());
-    const msg = encodeURIComponent(document.getElementById('message').value.trim());
-    const subject = `[Site RSE] Message de ${nom}`;
-    const body = `Nom: ${nom}%0D%0AEmail: ${email}%0D%0A%0D%0A${msg}`;
-    window.location.href = `mailto:ostanin.mikhail@gmail.com?subject=${subject}&body=${body}`;
-    document.getElementById('ok').style.display = 'block';
-  }
-
-  // reveal анимации
-  const io = new IntersectionObserver((es)=>es.forEach(e=>{ if(e.isIntersecting) e.target.classList.add('reveal') }), {threshold:.22});
-  document.querySelectorAll('.will-reveal').forEach(el=>io.observe(el));
-</script>
+<script src="app.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,225 @@
+:root{
+  --ink:#0e0e0e; --muted:#5f6b76; --line:#e9edf2;
+  --accent:#5D2DE6; --accent2:#0a6cc2;
+  --radius:18px; --shadow:0 10px 30px rgba(0,0,0,.10);
+  --maxw:1120px;
+}
+
+/* Base */
+html,body{
+  background:
+    radial-gradient(1400px 900px at 15% -10%, #fff7f0 0,#f1f6ff 40%, #ffffff 80%),
+    repeating-conic-gradient(from 0deg at 40% 30%, rgba(0,0,0,.02) 0 12deg, transparent 12deg 24deg);
+  background-attachment: fixed;
+  color:var(--ink);
+  font-family:Inter,system-ui,Arial,sans-serif;
+}
+a{color:inherit;text-decoration:none}
+
+/* Layout helpers */
+.mo-wrap{max-width:var(--maxw);margin:0 auto;padding:22px}
+.mo-card{background:#fff;border:1px solid var(--line);border-radius:var(--radius);box-shadow:var(--shadow)}
+.mo-grid{display:grid;gap:18px}
+.mo-grid-3{grid-template-columns:repeat(3,1fr)}
+
+/* Nav */
+.mo-nav{position:sticky;top:0;backdrop-filter:blur(10px);background:rgba(255,255,255,.65);border-bottom:1px solid var(--line);z-index:20;display:flex;align-items:center;justify-content:space-between}
+.mo-brand{display:flex;gap:12px;align-items:center;font-weight:800}
+.mo-logo{width:36px;height:36px;border-radius:10px;background:
+  radial-gradient(120px 120px at 20% 20%, #9E81F0, #7241FF 60%), linear-gradient(45deg,#6bdcff,#e6d8ff);
+  box-shadow:var(--shadow);animation:mo-float 6s ease-in-out infinite}
+.mo-links a{margin-left:18px;color:#39424a;opacity:.9}
+
+/* Buttons */
+.mo-btn{display:inline-block;padding:12px 18px;border-radius:999px;font-weight:700;transition:.15s transform, .2s box-shadow}
+.mo-btn:hover{transform:translateY(-2px)}
+.mo-btn-primary{background:linear-gradient(135deg,var(--accent),var(--accent2));color:#fff;box-shadow:var(--shadow)}
+.mo-btn-ghost{border:1px solid var(--line);background:#fff}
+
+/* Hero */
+.mo-hero{padding:68px 0 40px;border-bottom:1px solid var(--line);position:relative;overflow:hidden}
+.mo-hero-grid{display:grid;grid-template-columns:1.1fr .9fr;gap:32px;align-items:center}
+.mo-kicker{color:var(--accent);font-weight:800;letter-spacing:.06em;text-transform:uppercase;font-size:.8rem}
+.mo-hero h1{font-size:clamp(30px,4.3vw,52px);line-height:1.08;margin:.3em 0}
+.mo-lead{color:var(--muted);font-size:1.08rem;max-width:62ch}
+.mo-hero-card{position:relative;text-align:center}
+.mo-blob{position:absolute;inset:-40px -30px auto auto;width:360px;height:360px;filter:blur(40px);opacity:.45;z-index:-1;
+  background:radial-gradient(closest-side, #8fb7ff 0%, transparent 70%),
+             radial-gradient(closest-side, #b79bff 0%, transparent 70%),
+             radial-gradient(closest-side, #8ffff0 0%, transparent 70%);
+  mix-blend-mode:multiply;border-radius:50%;animation:mo-blob 12s ease-in-out infinite alternate}
+.mo-portrait{width:260px;height:260px;border-radius:50%;overflow:hidden;border:8px solid #fff;box-shadow:var(--shadow);margin:0 auto;transform:translateZ(0);transition:transform .3s ease}
+.mo-portrait:hover{transform:scale(1.02)}
+.mo-tag{position:absolute;bottom:-10px;left:50%;transform:translateX(-50%);background:#fff;border:1px solid var(--line);border-radius:999px;padding:8px 12px;box-shadow:var(--shadow);font-weight:700}
+
+/* Sections */
+.mo-section{padding:56px 0;border-bottom:1px solid var(--line)}
+.mo-section h2{font-size:clamp(22px,3.2vw,34px);margin:0 0 12px}
+.mo-service{padding:18px}
+.mo-service p{color:var(--muted)}
+
+/* Collaboration */
+.mo-collab{display:grid;grid-template-columns:1.05fr .95fr;gap:0;align-items:stretch;border-radius:22px;overflow:hidden}
+.mo-c-text{padding:28px}
+.mo-c-visual{position:relative;min-height:360px}
+.mo-c-visual img{position:absolute;inset:0;width:100%;height:100%;object-fit:cover}
+.mo-overlay{position:absolute;inset:0;background:linear-gradient(90deg, rgba(0,0,0,.35), rgba(0,0,0,.15))}
+.mo-pill{display:inline-block;margin-top:10px;background:#fff;border:1px solid var(--line);border-radius:999px;padding:8px 12px;font-weight:700}
+
+/* Footer */
+.mo-footer{padding:28px 0;color:#6b757f}
+.mo-split{display:flex;flex-wrap:wrap;gap:14px}
+.mo-split>*{flex:1 1 280px}
+
+/* Forms & 2-cols grid */
+.mo-grid-2{
+  display:grid;
+  grid-template-columns:1fr 1fr;
+  gap:18px;
+}
+.mo-input{
+  display:block;
+  width:100%;
+  padding:12px 14px;
+  border:1px solid var(--line);
+  border-radius:12px;
+  background:#fff;
+  color:var(--ink);
+  font:inherit;
+  outline:none;
+  transition:border-color .15s ease, box-shadow .15s ease, background-color .2s ease;
+}
+.mo-input::placeholder{color:var(--muted)}
+.mo-input:focus-visible{
+  border-color:var(--accent);
+  box-shadow:0 0 0 3px color-mix(in oklab, var(--accent) 20%, transparent);
+  background:#fff;
+}
+textarea.mo-input{min-height:140px;resize:vertical}
+.mo-card .mo-input{margin-bottom:12px}
+.mo-card button.mo-btn{margin-top:6px}
+
+/* Mission (no animations) */
+.mission-section {
+  --bg: #0b1114;
+  --card: #0f161a;
+  --text: #e8f1f3;
+  --muted: #b8c6c9;
+  --accent: #4dd4a2;
+  --line: rgba(255,255,255,.08);
+
+  background: radial-gradient(1200px 600px at 10% 0%, #102226 0%, var(--bg) 55%) no-repeat var(--bg);
+  color: var(--text);
+  padding: clamp(32px, 6vw, 80px) clamp(16px, 5vw, 64px);
+}
+.mission-wrap {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: clamp(20px, 4vw, 40px);
+  max-width: 1100px;
+  margin: 0 auto;
+  align-items: center;
+}
+@media (min-width: 880px) {
+  .mission-wrap { grid-template-columns: 1fr 1.2fr; }
+}
+.mission-figure {
+  margin: 0;
+  border-radius: 20px;
+  overflow: clip;
+  background: linear-gradient(180deg, rgba(77,212,162,.25), transparent 60%);
+  border: 1px solid var(--line);
+  box-shadow: 0 10px 30px rgba(0,0,0,.35);
+}
+.mission-figure img {
+  display: block;
+  width: 100%;
+  height: auto;
+  aspect-ratio: 3/4;
+  object-fit: cover;
+  filter: saturate(1.05) contrast(1.03);
+}
+.mission-content {
+  background: linear-gradient(180deg, rgba(77,212,162,.06), rgba(77,212,162,.0));
+  border: 1px solid var(--line);
+  border-radius: 20px;
+  padding: clamp(20px, 3.5vw, 36px);
+  box-shadow: 0 10px 30px rgba(0,0,0,.28);
+}
+.mission-kicker {
+  display: inline-block;
+  font-size: 12px;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+  color: var(--accent);
+  background: rgba(77,212,162,.12);
+  border: 1px solid rgba(77,212,162,.25);
+  padding: 6px 10px;
+  border-radius: 999px;
+  margin-bottom: 10px;
+}
+.mission-title {
+  font-size: clamp(28px, 4.2vw, 44px);
+  line-height: 1.1;
+  margin: 6px 0 14px;
+  letter-spacing: -0.02em;
+}
+.mission-lead {
+  color: var(--muted);
+  font-size: clamp(16px, 1.6vw, 18px);
+  line-height: 1.6;
+  margin: 0 0 18px;
+}
+.mission-list {
+  display: grid;
+  gap: 10px;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+.mission-list li {
+  display: grid;
+  grid-template-columns: 28px 1fr;
+  align-items: start;
+  gap: 12px;
+  padding: 12px 14px;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: rgba(255,255,255,.02);
+  color: var(--text);
+}
+.mission-list li .check {
+  width: 22px;
+  height: 22px;
+  flex: none;
+  fill: var(--accent);
+  filter: drop-shadow(0 0 6px rgba(77,212,162,.25));
+  margin-top: 2px;
+}
+
+/* A11y helper */
+.visually-hidden {
+  position: absolute !important;
+  clip: rect(1px, 1px, 1px, 1px);
+  padding: 0; border: 0; height: 1px; width: 1px; overflow: hidden;
+}
+
+/* Responsive */
+@media (max-width:980px){
+  .mo-hero-grid,.mo-collab{grid-template-columns:1fr}
+  .mo-collab{border-radius:18px}
+  .mo-grid-2{grid-template-columns:1fr} /* 2-cols -> 1-col on mobile */
+}
+
+/* Animations (global) */
+@keyframes mo-float{0%,100%{transform:translateY(0)}50%{transform:translateY(-4px)}}
+@keyframes mo-blob{0%{transform:translate(0,0) scale(1)}100%{transform:translate(-20px,10px) scale(1.08)}}
+
+/* Light theme fallback for Mission */
+@media (prefers-color-scheme: light) {
+  .mission-section {
+    --bg: #f4faf8; --card: #ffffff; --text: #0b1a17; --muted: #425654; --accent: #1f9e77; --line: rgba(2,35,28,.12);
+    background: radial-gradient(1200px 600px at 10% 0%, #e9f6f1 0%, var(--bg) 60%) no-repeat var(--bg);
+  }
+  .mission-figure, .mission-content, .mission-list li { box-shadow: 0 10px 24px rgba(16, 46, 39, .08); }
+}


### PR DESCRIPTION
## Summary
- rewrite landing page markup with new `mo-` sections
- extract footer year and mailto logic into `app.js`
- add global stylesheet for layout, navigation, mission, and responsive tweaks

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d4642174832cbd094d898e102b3b