### PR TITLE
Add focus styles for buttons and pills

### DIFF
--- a/style.css
+++ b/style.css
@@ -36,6 +36,10 @@ a{color:inherit;text-decoration:none}
 .mo-btn:hover{transform:translateY(-2px)}
 .mo-btn-primary{background:linear-gradient(135deg,var(--accent),var(--accent2));color:#fff;box-shadow:var(--shadow)}
 .mo-btn-ghost{border:1px solid var(--line);background:#fff}
+.mo-btn:focus-visible, .mo-pill:focus-visible{
+  outline:none;
+  box-shadow:0 0 0 2px #fff,0 0 0 4px var(--accent);
+}
 
 /* Hero */
 .mo-hero{padding:68px 0 40px;border-bottom:1px solid var(--line);position:relative;overflow:hidden}


### PR DESCRIPTION
## Summary
- add `:focus-visible` styles for `.mo-btn` and `.mo-pill`
- use dual box-shadow ring to provide accessible focus contrast

## Testing
- `npx -p puppeteer node - <<'NODE'...` *(failed: 403 Forbidden - GET https://registry.npmjs.org/puppeteer)*

------
https://chatgpt.com/codex/tasks/task_e_68b2399b49b4832c9a06c14c71cc62bd