### PR TITLE
Highlight card links with accent

### DIFF
--- a/style.css
+++ b/style.css
@@ -16,6 +16,14 @@ html,body{
   font-family:Inter,system-ui,Arial,sans-serif;
 }
 a{color:inherit;text-decoration:none}
+.mo-card a{
+  color:var(--accent);
+  text-decoration:underline;
+  transition:color .2s ease;
+}
+.mo-card a:hover,.mo-card a:focus-visible{
+  color:var(--accent2);
+}
 
 /* Layout helpers */
 .mo-wrap{max-width:var(--maxw);margin:0 auto;padding:22px}


### PR DESCRIPTION
## Summary
- style card links with accent color and underline
- add hover and focus states for card anchors

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b240f76ed8832c8bd5982bb971b5c5