### PR TITLE
Add border-box sizing for contact form inputs

### DIFF
--- a/style.css
+++ b/style.css
@@ -104,6 +104,7 @@ a{color:inherit;text-decoration:none}
   font:inherit;
   outline:none;
   transition:border-color .15s ease, box-shadow .15s ease, background-color .2s ease;
+  box-sizing:border-box;
 }
 .mo-input::placeholder{color:var(--muted)}
 .mo-input:focus-visible{


### PR DESCRIPTION
## Summary
- ensure form inputs use `box-sizing: border-box` to stay within their container

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python3 -m http.server` *(served site locally; verified contact section HTML via curl)*


------
https://chatgpt.com/codex/tasks/task_e_68b242f6b180832cb7651d841cb7be22