### PR TITLE
Add reveal-on-scroll animations

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,6 +2,17 @@
 document.addEventListener('DOMContentLoaded', () => {
   const yearEl = document.getElementById('mo-year');
   if (yearEl) yearEl.textContent = new Date().getFullYear();
+
+  const revealEls = document.querySelectorAll('.mo-reveal');
+  const observer = new IntersectionObserver((entries, obs) => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        entry.target.classList.add('is-visible');
+        obs.unobserve(entry.target);
+      }
+    });
+  }, { threshold: 0.1 });
+  revealEls.forEach(el => observer.observe(el));
 });
 
 // 2) Mailto без бэкенда

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
 
 <main id="top">
   <!-- HERO -->
-  <section class="mo-hero" aria-labelledby="hero-title">
+  <section class="mo-hero mo-reveal" aria-labelledby="hero-title">
     <div class="mo-wrap mo-hero-grid">
       <div>
         <p class="mo-kicker">RSE • Bilans carbone • Reporting</p>
@@ -53,7 +53,7 @@
   </section>
 
   <!-- MISSION -->
-  <section id="mission" class="mission-section" aria-labelledby="mission-title">
+  <section id="mission" class="mission-section mo-reveal" aria-labelledby="mission-title">
     <div class="mission-wrap">
       <figure class="mission-figure">
         <img
@@ -96,9 +96,9 @@
   </section>
 
   <!-- COLLAB -->
-  <section id="collab" class="mo-section" aria-labelledby="collab-title">
+  <section id="collab" class="mo-section mo-reveal" aria-labelledby="collab-title">
     <div class="mo-wrap">
-      <div class="mo-collab mo-card">
+      <div class="mo-collab mo-card mo-reveal">
         <div class="mo-c-text">
           <h2 id="collab-title">Collaboration</h2>
           <h3>Construisons ensemble vos projets RSE</h3>
@@ -119,19 +119,19 @@
   </section>
 
   <!-- SERVICES -->
-  <section id="services" class="mo-section" aria-labelledby="services-title">
+  <section id="services" class="mo-section mo-reveal" aria-labelledby="services-title">
     <div class="mo-wrap">
       <h2 id="services-title">Services</h2>
       <div class="mo-grid mo-grid-3">
-        <article class="mo-card mo-service">
+        <article class="mo-card mo-service mo-reveal">
           <h3>Bilans carbone</h3>
           <p class="mo-muted">Périmètres 1–2–3, calculs, rapport & plan d’actions.</p>
         </article>
-        <article class="mo-card mo-service">
+        <article class="mo-card mo-service mo-reveal">
           <h3>Reporting RSE</h3>
           <p class="mo-muted">KPI, tableaux de bord, matérialité, traçabilité.</p>
         </article>
-        <article class="mo-card mo-service">
+        <article class="mo-card mo-service mo-reveal">
           <h3>Ateliers</h3>
           <p class="mo-muted">Climat, déchets, mobilité, alimentation durable.</p>
         </article>
@@ -140,11 +140,11 @@
   </section>
 
   <!-- CONTACT -->
-  <section id="contact" class="mo-section" aria-labelledby="contact-title">
+  <section id="contact" class="mo-section mo-reveal" aria-labelledby="contact-title">
     <div class="mo-wrap">
       <h2 id="contact-title">Contact</h2>
       <div class="mo-grid mo-grid-2">
-        <form class="mo-card mo-card-pad" onsubmit="moSendMail(event)">
+        <form class="mo-card mo-card-pad mo-reveal" onsubmit="moSendMail(event)">
           <label class="visually-hidden" for="mo-nom">Nom</label>
           <input id="mo-nom" name="nom" placeholder="Nom" required class="mo-input">
 
@@ -158,7 +158,7 @@
           <p id="mo-ok" class="mo-muted" hidden>Merci ! Un e-mail est prêt dans votre client.</p>
         </form>
 
-        <div class="mo-card mo-card-pad">
+        <div class="mo-card mo-card-pad mo-reveal">
           <h3>Coordonnées</h3>
           <address>
             <strong>Mikhail Ostanin</strong><br>

--- a/style.css
+++ b/style.css
@@ -235,6 +235,17 @@ textarea.mo-input{min-height:140px;resize:vertical}
   padding: 0; border: 0; height: 1px; width: 1px; overflow: hidden;
 }
 
+/* Reveal animation */
+.mo-reveal {
+  opacity:0;
+  transform:translateY(20px);
+  transition:opacity .6s ease, transform .6s ease;
+}
+.mo-reveal.is-visible {
+  opacity:1;
+  transform:none;
+}
+
 /* Responsive */
 @media (max-width:980px){
   .mo-hero-grid,.mo-collab{grid-template-columns:1fr}


### PR DESCRIPTION
## Summary
- add reusable `mo-reveal` CSS for hidden/visible states
- apply `mo-reveal` to sections and cards to trigger fade-up animation
- observe `.mo-reveal` elements with `IntersectionObserver`

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68b5b55ff8fc832caa5286c17775e3a9