### PR TITLE
Unify button styling and hover effect

### DIFF
--- a/style.css
+++ b/style.css
@@ -51,10 +51,28 @@ a{color:inherit;text-decoration:none}
 .mo-links a:hover,.mo-links a:focus-visible{color:var(--accent);text-decoration:underline;opacity:1}
 
 /* Buttons */
-.mo-btn{display:inline-block;padding:12px 18px;border-radius:999px;font-weight:700;transition:.15s transform, .2s box-shadow}
-.mo-btn:hover{transform:translateY(-2px)}
-.mo-btn-primary{background:linear-gradient(135deg,var(--accent),var(--accent2));color:#fff;box-shadow:var(--shadow)}
-.mo-btn-ghost{border:1px solid var(--line);background:#fff}
+.mo-btn{
+  display:inline-block;
+  padding:12px 18px;
+  border-radius:999px;
+  font-weight:700;
+  background:var(--accent);
+  color:#fff;
+  box-shadow:var(--shadow);
+  transition:.15s transform, .2s box-shadow, .2s background-color;
+}
+.mo-btn:hover{
+  background:var(--accent2);
+  color:#fff;
+  transform:translateY(-2px);
+}
+/* Removed mo-btn-primary in favor of base .mo-btn styling */
+.mo-btn-ghost{
+  border:1px solid var(--accent);
+  background:#fff;
+  color:var(--accent);
+  box-shadow:none;
+}
 .mo-btn:focus-visible, .mo-pill:focus-visible{
   outline:none;
   box-shadow:0 0 0 2px #fff,0 0 0 4px var(--accent);


### PR DESCRIPTION
## Summary
- set base `.mo-btn` style with accent background, white text, and hover state using `--accent2`
- remove dedicated `.mo-btn-primary` rule and align `.mo-btn-ghost` with accent color scheme

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b5823924832cb34c0e36a17ca923