### PR TITLE
Enlarge hero portrait and update styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
         <figure class="mo-portrait">
           <img src="https://ostanin-rse.fr/wp-content/uploads/2025/08/me.jpg"
                alt="Portrait — Mikhail Ostanin"
-               width="260" height="260"
+               width="320" height="320"
                loading="lazy" decoding="async"
                style="width:100%;height:100%;object-fit:cover">
         </figure>

--- a/style.css
+++ b/style.css
@@ -72,7 +72,7 @@ a{color:inherit;text-decoration:none}
              radial-gradient(closest-side, #b79bff 0%, transparent 70%),
              radial-gradient(closest-side, #8ffff0 0%, transparent 70%);
   mix-blend-mode:multiply;border-radius:50%;animation:mo-blob 12s ease-in-out infinite alternate}
-.mo-portrait{width:260px;height:260px;border-radius:50%;overflow:hidden;border:8px solid #fff;box-shadow:var(--shadow);margin:0 auto;transform:translateZ(0);transition:transform .3s ease}
+.mo-portrait{width:320px;height:320px;border-radius:20px;overflow:hidden;border:8px solid #fff;box-shadow:var(--shadow);margin:0 auto;transform:translateZ(0);transition:transform .3s ease}
 .mo-portrait:hover{transform:scale(1.02)}
 .mo-tag{position:absolute;bottom:-10px;left:50%;transform:translateX(-50%);background:#fff;border:1px solid var(--line);border-radius:999px;padding:8px 12px;box-shadow:var(--shadow);font-weight:700}
 


### PR DESCRIPTION
## Summary
- enlarge hero portrait to 320x320 and switch to 20px rounded corners
- update HTML image attributes to match new dimensions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b5851b90832ca5cf9e87887ce8e4