### PR TITLE
feat: send contact form via backend

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,7 +4,7 @@ document.addEventListener('DOMContentLoaded', () => {
   if (yearEl) yearEl.textContent = new Date().getFullYear();
 });
 
-// 2) Mailto без бэкенда
+// 2) Отправка формы через бэкенд
 function moSendMail(e) {
   e.preventDefault();
 
@@ -16,15 +16,29 @@ function moSendMail(e) {
   const email = (emailEl?.value || '').trim();
   const msg = (msgEl?.value || '').trim();
 
-  const subject = `[Site RSE] Message de ${nom || 'Client'}`;
-  const body =
-    `Nom: ${nom}\n` +
-    `Email: ${email}\n\n` +
-    `${msg}`;
-
-  const href = `mailto:contact@ostanin-rse.fr?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
-  window.location.href = href;
-
-  const ok = document.getElementById('mo-ok');
-  if (ok) ok.hidden = false;
+  fetch('/api/contact', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ nom, email, msg })
+  })
+    .then((res) => {
+      if (!res.ok) throw new Error('Network response was not ok');
+      return res.json();
+    })
+    .then(() => {
+      const ok = document.getElementById('mo-ok');
+      if (ok) {
+        ok.textContent = 'Merci, votre message a été envoyé.';
+        ok.hidden = false;
+        ok.style.color = '';
+      }
+    })
+    .catch(() => {
+      const ok = document.getElementById('mo-ok');
+      if (ok) {
+        ok.textContent = "Une erreur s'est produite. Veuillez réessayer.";
+        ok.hidden = false;
+        ok.style.color = 'red';
+      }
+    });
 }

--- a/index.html
+++ b/index.html
@@ -155,7 +155,7 @@
           <textarea id="mo-msg" name="message" rows="6" placeholder="Votre besoin (périmètre, délais, contraintes)…" required class="mo-input"></textarea>
 
           <button class="mo-btn mo-btn-primary" type="submit">Envoyer</button>
-          <p id="mo-ok" class="mo-muted" hidden>Merci ! Un e-mail est prêt dans votre client.</p>
+          <p id="mo-ok" class="mo-muted" hidden></p>
         </form>
 
         <div class="mo-card mo-card-pad">

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "1-project",
+  "version": "1.0.0",
+  "description": "",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "node -e \"require('./server')\""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^4.18.2",
+    "nodemailer": "^6.9.8",
+    "express-rate-limit": "^6.7.0"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,65 @@
+const express = require('express');
+const nodemailer = require('nodemailer');
+const rateLimit = require('express-rate-limit');
+
+const app = express();
+app.use(express.json());
+
+// Basic rate limiting to mitigate spam
+app.use(
+  rateLimit({
+    windowMs: 60 * 1000, // 1 minute
+    max: 5,
+    standardHeaders: true,
+    legacyHeaders: false,
+  })
+);
+
+// Create reusable transporter object using SMTP or JSON transport in test env
+function createTransport() {
+  if (process.env.NODE_ENV === 'test') {
+    return nodemailer.createTransport({ jsonTransport: true });
+  }
+  return nodemailer.createTransport({
+    host: process.env.SMTP_HOST,
+    port: parseInt(process.env.SMTP_PORT || '587', 10),
+    secure: false,
+    auth: {
+      user: process.env.SMTP_USER,
+      pass: process.env.SMTP_PASS,
+    },
+  });
+}
+
+const transporter = createTransport();
+
+app.post('/api/contact', async (req, res) => {
+  const { nom, email, msg } = req.body || {};
+  if (!nom || !email || !msg) {
+    return res.status(400).json({ error: 'Missing fields' });
+  }
+
+  const mail = {
+    from: process.env.SMTP_FROM || 'no-reply@ostanin-rse.fr',
+    to: 'contact@ostanin-rse.fr',
+    subject: `[Site RSE] Message de ${nom}`,
+    text: `Nom: ${nom}\nEmail: ${email}\n\n${msg}`,
+  };
+
+  try {
+    await transporter.sendMail(mail);
+    res.json({ ok: true });
+  } catch (err) {
+    console.error('Mail error', err);
+    res.status(500).json({ error: 'send_fail' });
+  }
+});
+
+const port = process.env.PORT || 3000;
+if (require.main === module) {
+  app.listen(port, () => {
+    console.log(`Server listening on port ${port}`);
+  });
+}
+
+module.exports = app;


### PR DESCRIPTION
## Summary
- add Express server with nodemailer and rate limiting to handle contact form
- send form via fetch and display success or error messages
- add package.json with server dependencies

## Testing
- `npm test` *(fails: Cannot find module 'express')*


------
https://chatgpt.com/codex/tasks/task_e_68b5b586d764832ca4d2d2fe913a555b