### PR TITLE
Add static file serving to Express server

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,9 +1,11 @@
 const express = require('express');
 const nodemailer = require('nodemailer');
 const rateLimit = require('express-rate-limit');
+const path = require('path');
 
 const app = express();
 app.use(express.json());
+app.use(express.static(path.join(__dirname)));
 
 // Basic rate limiting to mitigate spam
 app.use(


### PR DESCRIPTION
## Summary
- require Node's path module in server
- serve static front-end assets alongside API

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/express)*
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68b5b81a50d4832c82f5b146f3ae7800