### PR TITLE
Remove unused mo-btn-primary class

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
     <a href="#services">Services</a>
     <a href="#mission">Mission</a>
     <a href="#collab">Collaboration</a>
-    <a href="#contact" class="mo-btn mo-btn-primary">Devis</a>
+    <a href="#contact" class="mo-btn">Devis</a>
   </nav>
 </header>
 
@@ -33,7 +33,7 @@
           Approche orientée données, livrables prêts à l’emploi et plan d’actions priorisé.
         </p>
         <p>
-          <a class="mo-btn mo-btn-primary" href="#contact">Parler de votre projet</a>
+          <a class="mo-btn" href="#contact">Parler de votre projet</a>
           <a class="mo-btn mo-btn-ghost" href="#services" style="margin-left:8px">Voir les services</a>
         </p>
       </div>
@@ -154,7 +154,7 @@
           <label class="visually-hidden" for="mo-msg">Message</label>
           <textarea id="mo-msg" name="message" rows="6" placeholder="Votre besoin (périmètre, délais, contraintes)…" required class="mo-input"></textarea>
 
-          <button class="mo-btn mo-btn-primary" type="submit">Envoyer</button>
+          <button class="mo-btn" type="submit">Envoyer</button>
           <p id="mo-ok" class="mo-muted" hidden></p>
         </form>
 

--- a/style.css
+++ b/style.css
@@ -66,7 +66,6 @@ a{color:inherit;text-decoration:none}
   color:#fff;
   transform:translateY(-2px);
 }
-/* Removed mo-btn-primary in favor of base .mo-btn styling */
 .mo-btn-ghost{
   border:1px solid var(--accent);
   background:#fff;


### PR DESCRIPTION
## Summary
- replace `class="mo-btn mo-btn-primary"` occurrences with `class="mo-btn"`
- clean up stylesheet by removing outdated mo-btn-primary comment

## Testing
- `npm test` *(fails: Cannot find module 'express')*
- `npm install` *(fails: 403 Forbidden when fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b82c2f84832ca5b4a25f6a29b636