### PR TITLE
Use msg field for textarea

### DIFF
--- a/index.html
+++ b/index.html
@@ -152,7 +152,7 @@
           <input id="mo-email" name="email" type="email" placeholder="E-mail" required class="mo-input">
 
           <label class="visually-hidden" for="mo-msg">Message</label>
-          <textarea id="mo-msg" name="message" rows="6" placeholder="Votre besoin (périmètre, délais, contraintes)…" required class="mo-input"></textarea>
+          <textarea id="mo-msg" name="msg" rows="6" placeholder="Votre besoin (périmètre, délais, contraintes)…" required class="mo-input"></textarea>
 
           <button class="mo-btn mo-btn-primary" type="submit">Envoyer</button>
           <p id="mo-ok" class="mo-muted" hidden></p>


### PR DESCRIPTION
## Summary
- rename contact form textarea field from `message` to `msg`

## Testing
- `npm test` *(fails: Cannot find module 'express')*


------
https://chatgpt.com/codex/tasks/task_e_68b5b823dba4832cbd93ea578194ec51