### PR TITLE
Validate email format for contact endpoint

### DIFF
--- a/server.js
+++ b/server.js
@@ -39,6 +39,12 @@ app.post('/api/contact', async (req, res) => {
     return res.status(400).json({ error: 'Missing fields' });
   }
 
+  // Simple e-mail format validation
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  if (!emailRegex.test(email)) {
+    return res.status(400).json({ error: 'Invalid email format' });
+  }
+
   const mail = {
     from: process.env.SMTP_FROM || 'no-reply@ostanin-rse.fr',
     to: 'contact@ostanin-rse.fr',


### PR DESCRIPTION
## Summary
- validate email address format in `/api/contact`
- return 400 with error when email is invalid

## Testing
- `npm test` *(fails: Cannot find module 'express')*
- `npm install` *(fails: 403 Forbidden to registry.npmjs.org/express)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b84aa8e4832cab74605d619f8a09