### PR TITLE
Validate SMTP configuration before sending emails

### DIFF
--- a/server.js
+++ b/server.js
@@ -20,23 +20,42 @@ function createTransport() {
   if (process.env.NODE_ENV === 'test') {
     return nodemailer.createTransport({ jsonTransport: true });
   }
+  const { SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASS } = process.env;
+  const missing = [];
+  if (!SMTP_HOST) missing.push('SMTP_HOST');
+  if (!SMTP_PORT) missing.push('SMTP_PORT');
+  if (!SMTP_USER) missing.push('SMTP_USER');
+  if (!SMTP_PASS) missing.push('SMTP_PASS');
+  if (missing.length > 0) {
+    console.error(`Missing SMTP config: ${missing.join(', ')}`);
+    throw new Error('Missing SMTP configuration');
+  }
   return nodemailer.createTransport({
-    host: process.env.SMTP_HOST,
-    port: parseInt(process.env.SMTP_PORT || '587', 10),
+    host: SMTP_HOST,
+    port: parseInt(SMTP_PORT, 10),
     secure: false,
     auth: {
-      user: process.env.SMTP_USER,
-      pass: process.env.SMTP_PASS,
+      user: SMTP_USER,
+      pass: SMTP_PASS,
     },
   });
 }
 
-const transporter = createTransport();
+let transporter;
+try {
+  transporter = createTransport();
+} catch (err) {
+  console.error('Transporter setup failed', err);
+}
 
 app.post('/api/contact', async (req, res) => {
   const { nom, email, msg } = req.body || {};
   if (!nom || !email || !msg) {
     return res.status(400).json({ error: 'Missing fields' });
+  }
+
+  if (!transporter) {
+    return res.status(500).json({ error: 'smtp_unavailable' });
   }
 
   const mail = {


### PR DESCRIPTION
## Summary
- Add explicit checks for SMTP_HOST, SMTP_PORT, SMTP_USER and SMTP_PASS when creating the mail transporter
- Log configuration problems and avoid creating transporter when variables are missing
- Return `smtp_unavailable` error before attempting to send mail if transporter setup failed

## Testing
- `npm test` *(fails: Cannot find module 'express')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/express)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b8485abc832c8211355d5f41179a