### PR TITLE
Remove Devis navigation item

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,6 @@
     <a href="#services">Services</a>
     <a href="#mission">Mission</a>
     <a href="#collab">Collaboration</a>
-    <a href="#contact" class="mo-btn">Devis</a>
   </nav>
 </header>
 


### PR DESCRIPTION
## Summary
- remove the "Devis" button from the top navigation menu

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: Cannot find module 'express')*


------
https://chatgpt.com/codex/tasks/task_e_68b5be43fdc0832c800b7d0828e310df