### PR TITLE
Remove unused mo-tag element and styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,6 @@
                loading="lazy" decoding="async"
                style="width:100%;height:100%;object-fit:cover">
         </figure>
-        <div class="mo-tag" aria-hidden="true">Consultant RSE</div>
       </aside>
     </div>
   </section>

--- a/style.css
+++ b/style.css
@@ -91,7 +91,6 @@ a{color:inherit;text-decoration:none}
   mix-blend-mode:multiply;border-radius:50%;animation:mo-blob 12s ease-in-out infinite alternate}
 .mo-portrait{width:320px;height:320px;border-radius:20px;overflow:hidden;border:8px solid #fff;box-shadow:var(--shadow);margin:0 auto;transform:translateZ(0);transition:transform .3s ease}
 .mo-portrait:hover{transform:scale(1.02)}
-.mo-tag{position:absolute;bottom:-10px;left:50%;transform:translateX(-50%);background:#fff;border:1px solid var(--line);border-radius:999px;padding:8px 12px;box-shadow:var(--shadow);font-weight:700}
 
 /* Sections */
 .mo-section{padding:56px 0;border-bottom:1px solid var(--line)}


### PR DESCRIPTION
## Summary
- drop Consultant RSE mo-tag element from hero card
- remove unused `.mo-tag` styles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5be4a9338832cae3581889b0e2f48