### PR TITLE
Add interactive service cards with collapsible details

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/app.js
+++ b/app.js
@@ -13,6 +13,49 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }, { threshold: 0.1 });
   revealEls.forEach(el => observer.observe(el));
+
+  const serviceCards = document.querySelectorAll('.mo-service');
+  serviceCards.forEach(card => {
+    const btn = card.querySelector('.service-toggle');
+    const panel = card.querySelector('.service-panel');
+    if (!btn || !panel) return;
+
+    const open = () => {
+      panel.hidden = false;
+      btn.setAttribute('aria-expanded', 'true');
+      card.classList.add('is-open');
+    };
+    const close = () => {
+      panel.hidden = true;
+      btn.setAttribute('aria-expanded', 'false');
+      card.classList.remove('is-open');
+    };
+
+    btn.addEventListener('click', e => {
+      e.preventDefault();
+      const expanded = btn.getAttribute('aria-expanded') === 'true';
+      expanded ? close() : open();
+      delete card.dataset.hover;
+    });
+    btn.addEventListener('keydown', e => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        btn.click();
+      }
+    });
+    card.addEventListener('mouseenter', () => {
+      if (btn.getAttribute('aria-expanded') === 'false') {
+        open();
+        card.dataset.hover = '1';
+      }
+    });
+    card.addEventListener('mouseleave', () => {
+      if (card.dataset.hover) {
+        close();
+        delete card.dataset.hover;
+      }
+    });
+  });
 });
 
 // 2) Mailto без бэкенда

--- a/index.html
+++ b/index.html
@@ -126,16 +126,74 @@
       <h2 id="services-title">Services</h2>
       <div class="mo-grid mo-grid-3">
         <article class="mo-card mo-service mo-reveal">
-          <h3>Bilans carbone</h3>
-          <p class="mo-muted">Périmètres 1–2–3, calculs, rapport & plan d’actions.</p>
+          <h3>
+            <button class="service-toggle" aria-expanded="false" aria-controls="service-a">
+              Reporting RSE &amp; conformité réglementaire
+            </button>
+          </h3>
+          <div id="service-a" class="service-panel" hidden>
+            <ul>
+              <li>Préparation au reporting extra-financier (CSRD, taxonomie européenne)</li>
+              <li>Mise en place de tableaux de bord RSE</li>
+              <li>Appui aux démarches de labellisation et d’accréditation</li>
+            </ul>
+          </div>
         </article>
         <article class="mo-card mo-service mo-reveal">
-          <h3>Reporting RSE</h3>
-          <p class="mo-muted">KPI, tableaux de bord, matérialité, traçabilité.</p>
+          <h3>
+            <button class="service-toggle" aria-expanded="false" aria-controls="service-b">
+              Sensibilisation &amp; formation
+            </button>
+          </h3>
+          <div id="service-b" class="service-panel" hidden>
+            <ul>
+              <li>Ateliers participatifs pour salariés, étudiants ou dirigeants</li>
+              <li>Modules sur la transition durable et les éco-gestes</li>
+              <li>Création de contenus pédagogiques (guides, e-learning, visuels)</li>
+            </ul>
+          </div>
         </article>
         <article class="mo-card mo-service mo-reveal">
-          <h3>Ateliers</h3>
-          <p class="mo-muted">Climat, déchets, mobilité, alimentation durable.</p>
+          <h3>
+            <button class="service-toggle" aria-expanded="false" aria-controls="service-c">
+              Stratégie RSE &amp; labels
+            </button>
+          </h3>
+          <div id="service-c" class="service-panel" hidden>
+            <ul>
+              <li>Feuille de route RSE adaptée à votre secteur</li>
+              <li>Accompagnement à l’obtention de labels</li>
+              <li>Intégration des enjeux dans la stratégie globale</li>
+            </ul>
+          </div>
+        </article>
+        <article class="mo-card mo-service mo-reveal">
+          <h3>
+            <button class="service-toggle" aria-expanded="false" aria-controls="service-d">
+              Communication responsable
+            </button>
+          </h3>
+          <div id="service-d" class="service-panel" hidden>
+            <ul>
+              <li>Élaboration de la stratégie RSE (interne et externe)</li>
+              <li>Création de contenus éditoriaux et visuels</li>
+              <li>Valorisation des actions auprès des parties prenantes</li>
+            </ul>
+          </div>
+        </article>
+        <article class="mo-card mo-service mo-reveal">
+          <h3>
+            <button class="service-toggle" aria-expanded="false" aria-controls="service-e">
+              Événementiel durable
+            </button>
+          </h3>
+          <div id="service-e" class="service-panel" hidden>
+            <ul>
+              <li>Organisation ou co-organisation d’événements de sensibilisation</li>
+              <li>Coordination avec les équipes internes et partenaires</li>
+              <li>Animation de sessions thématiques et restitution des résultats</li>
+            </ul>
+          </div>
         </article>
       </div>
     </div>

--- a/style.css
+++ b/style.css
@@ -89,8 +89,42 @@ a{color:inherit;text-decoration:none}
 /* Sections */
 .mo-section{padding:56px 0;border-bottom:1px solid var(--line)}
 .mo-section h2{font-size:clamp(22px,3.2vw,34px);margin:0 0 12px}
-.mo-service{padding:18px}
+.mo-service{padding:clamp(16px,4vw,24px)}
+.mo-service h3{margin:0;font-size:clamp(18px,2.6vw,22px)}
 .mo-service p{color:var(--muted)}
+
+.service-toggle{
+  display:block;
+  width:100%;
+  text-align:left;
+  background:none;
+  border:none;
+  padding:0;
+  font:inherit;
+  color:inherit;
+  cursor:pointer;
+}
+.service-toggle:focus-visible{
+  outline:none;
+  box-shadow:0 0 0 2px var(--accent);
+}
+.service-panel{
+  max-height:0;
+  overflow:hidden;
+  opacity:0;
+  transition:max-height .3s ease, opacity .3s ease;
+}
+.mo-service.is-open .service-panel{
+  max-height:600px;
+  opacity:1;
+  margin-top:12px;
+}
+.service-panel ul{
+  margin:0;
+  padding-left:20px;
+  font-size:clamp(14px,1.8vw,16px);
+  color:var(--muted);
+}
 
 /* Collaboration */
 .mo-collab{display:grid;grid-template-columns:1.05fr .95fr;gap:0;align-items:stretch;border-radius:22px;overflow:hidden}


### PR DESCRIPTION
## Summary
- replace services section with five interactive cards and bullet panels
- style collapsible panels with responsive typography and animations
- add JS listeners for click/hover toggling with ARIA accessibility

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d4ff8150832c9628c1f08b76cca2