### PR TITLE
Adjust Mission list spacing

### DIFF
--- a/style.css
+++ b/style.css
@@ -259,31 +259,34 @@ textarea.mo-input{min-height:140px;resize:vertical}
   line-height: 1.6;
   margin: 0 0 18px;
 }
+
+/* === Правка внутренних отступов списка в блоке Mission === */
 .mission-list {
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: 10px;
   padding: 0;
-  margin: 0;
+  margin: 10px 0 16px;
   list-style: none;
 }
 .mission-list li {
-  display: grid;
-  grid-template-columns: 28px 1fr;
-  align-items: start;
+  display: flex;
+  align-items: center;
   gap: 12px;
-  padding: 12px 14px;
+  padding: 12px 16px;
   border: 1px solid var(--line);
   border-radius: 14px;
   background: rgba(255,255,255,.02);
+  line-height: 1.5;
   color: var(--text);
+  font-size: 1rem;
 }
 .mission-list li .check {
   width: 22px;
   height: 22px;
-  flex: none;
+  flex-shrink: 0;
   fill: var(--accent);
   filter: drop-shadow(0 0 6px rgba(77,212,162,.25));
-  margin-top: 2px;
 }
 
 /* A11y helper */


### PR DESCRIPTION
## Summary
- refine Mission list spacing and layout with flex column styling
- align list items, update padding, line-height, and sizing for improved readability
- tweak check icon to prevent shrink and maintain accent style

## Testing
- `npm test` *(fails: ENOENT, no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b60582f16c832c9bde1cd422705330