### PR TITLE
refactor: consolidate layout helpers

### DIFF
--- a/style.css
+++ b/style.css
@@ -4,6 +4,10 @@
   --radius:18px; --shadow:0 10px 30px rgba(0,0,0,.10);
   --maxw:1120px;
   --space-xs:8px; --space-s:12px; --space-m:18px; --space-l:24px;
+  --wrap-pad-y:var(--space-m);
+  --hero-pad-top:clamp(16px,4vw,28px);
+  --hero-pad-bottom:clamp(24px,5vw,36px);
+  --grid-gap:var(--space-s);
 }
 
 /* Base */
@@ -31,11 +35,11 @@ a{color:inherit;text-decoration:none}
 }
 
 /* Layout helpers */
-.mo-wrap{max-width:var(--maxw);margin:0 auto;padding:var(--space-l)}
+.mo-wrap{max-width:var(--maxw);margin:0 auto;padding:var(--wrap-pad-y) var(--space-l)}
 .mo-card{background:#fff;border:1px solid var(--line);border-radius:var(--radius);box-shadow:var(--shadow);transition:transform .2s ease,box-shadow .2s ease}
 .mo-card:hover{box-shadow:0 12px 34px rgba(0,0,0,.14);transform:scale(1.02)}
 .mo-card-pad{padding:var(--space-m)}
-.mo-grid{display:grid;gap:var(--space-m)}
+.mo-grid{display:grid;gap:var(--grid-gap)}
 .mo-grid-3{grid-template-columns:repeat(3,1fr)}
 
 /* Nav */
@@ -73,7 +77,7 @@ a{color:inherit;text-decoration:none}
 /* === Fix hero top spacing === */
 .home .wp-site-blocks{padding-top:0}
 .home .wp-site-blocks>*:first-child{margin-top:0}
-.mo-hero{padding:var(--space-l) 0 40px;border-bottom:1px solid var(--line);position:relative;overflow:hidden}
+.mo-hero{padding:var(--hero-pad-top) 0 var(--hero-pad-bottom);border-bottom:1px solid var(--line);position:relative;overflow:hidden}
 .mo-hero .mo-wrap{padding-top:0}
 
 /* === Align hero grid content vertically === */
@@ -427,23 +431,10 @@ p, li {
   padding: clamp(var(--section-y-min), 6vw, var(--section-y-max)) 0;
 }
 
-/* Чуть компактнее контейнер по вертикали (горизонтальные отступы как были) */
-.mo-wrap{
-  padding: var(--space-m) var(--space-l);
-}
-
-/* Герой делаем ещё плотнее сверху и снизу */
-.mo-hero{
-  padding: clamp(16px, 4vw, 28px) 0 clamp(24px, 5vw, 36px);
-}
-
 /* Заголовки секций — меньше «воздуха» снизу */
 .mo-section h2{
   margin: 0 0 var(--space-xs);
 }
-
-/* Сетка — немного меньше промежутки между карточками/колонками */
-.mo-grid{ gap: var(--space-s); }
 
 /* Индивидуальные твики при желании (можно удалить/оставить) */
 #services.mo-section{ padding: clamp(24px, 5vw, 36px) 0; }


### PR DESCRIPTION
## Summary
- add CSS variables for common layout paddings and grid gap
- refactor `.mo-wrap`, `.mo-hero`, and `.mo-grid` to use variables
- remove duplicate style blocks for layout helpers

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b614d74b78832c9a9c46d8f5e4f1a5