### PR TITLE
Remove font declarations from stylesheet

### DIFF
--- a/style.css
+++ b/style.css
@@ -18,7 +18,6 @@ html,body{
     repeating-conic-gradient(from 0deg at 40% 30%, rgba(0,0,0,.02) 0 12deg, transparent 12deg 24deg);
   background-attachment: fixed;
   color:var(--ink);
-  font-family:Inter,system-ui,Arial,sans-serif;
 }
 a{color:inherit;text-decoration:none}
 .mo-card a,
@@ -30,7 +29,6 @@ a{color:inherit;text-decoration:none}
   color:var(--accent2);
 }
 .mo-card address{
-  font-style:normal;
   line-height:1.5;
 }
 
@@ -44,7 +42,7 @@ a{color:inherit;text-decoration:none}
 
 /* Nav */
 .mo-nav{position:sticky;top:0;backdrop-filter:blur(10px);background:rgba(255,255,255,.65);border-bottom:1px solid var(--line);z-index:20;display:flex;align-items:center;justify-content:space-between}
-.mo-brand{display:flex;gap:var(--space-s);align-items:center;font-weight:800}
+.mo-brand{display:flex;gap:var(--space-s);align-items:center}
 .mo-logo{width:36px;height:36px;border-radius:10px;background:
   radial-gradient(120px 120px at 20% 20%, #9E81F0, #7241FF 60%), linear-gradient(45deg,#6bdcff,#e6d8ff);
   box-shadow:var(--shadow);animation:mo-float 6s ease-in-out infinite}
@@ -58,7 +56,6 @@ a{color:inherit;text-decoration:none}
   text-decoration:none;
   padding:var(--space-s) var(--space-m);
   border-radius:999px;
-  font-weight:700;
   background:var(--accent);
   color:#fff;
   box-shadow:var(--shadow);
@@ -82,9 +79,9 @@ a{color:inherit;text-decoration:none}
 
 /* === Align hero grid content vertically === */
 .mo-hero .mo-hero-grid{display:grid;grid-template-columns:1.1fr .9fr;gap:32px;align-items:center}
-.mo-kicker{color:var(--accent);font-weight:800;letter-spacing:.06em;text-transform:uppercase;font-size:.8rem}
-.mo-hero h1{font-size:clamp(30px,4.3vw,52px);line-height:1.08;margin:0 0 .3em}
-.mo-lead{color:var(--muted);font-size:1.08rem;max-width:62ch}
+.mo-kicker{color:var(--accent);letter-spacing:.06em;text-transform:uppercase}
+.mo-hero h1{line-height:1.08;margin:0 0 .3em}
+.mo-lead{color:var(--muted);max-width:62ch}
 
 /* === CTA buttons in one line === */
 .mo-cta{display:flex;flex-wrap:wrap;gap:var(--space-xs);margin-top:16px}
@@ -103,7 +100,7 @@ a{color:inherit;text-decoration:none}
 
 /* Sections */
 .mo-service{padding:clamp(16px,4vw,24px)}
-.mo-service h3{margin:0;font-size:clamp(18px,2.6vw,22px)}
+.mo-service h3{margin:0}
 .mo-service p{color:var(--muted)}
 
 .service-toggle{
@@ -113,7 +110,6 @@ a{color:inherit;text-decoration:none}
   background:none;
   border:none;
   padding:0;
-  font:inherit;
   color:inherit;
   cursor:pointer;
 }
@@ -135,7 +131,6 @@ a{color:inherit;text-decoration:none}
 .service-panel ul{
   margin:0;
   padding-left:20px;
-  font-size:clamp(14px,1.8vw,16px);
   color:var(--muted);
 }
 
@@ -145,7 +140,7 @@ a{color:inherit;text-decoration:none}
 .mo-c-visual{position:relative;min-height:360px}
 .mo-c-visual img{position:absolute;inset:0;width:100%;height:100%;object-fit:cover}
 .mo-overlay{position:absolute;inset:0;background:linear-gradient(90deg, rgba(0,0,0,.35), rgba(0,0,0,.15))}
-.mo-pill{display:inline-block;margin-top:10px;background:#fff;border:1px solid var(--line);border-radius:999px;padding:var(--space-xs) var(--space-s);font-weight:700}
+.mo-pill{display:inline-block;margin-top:10px;background:#fff;border:1px solid var(--line);border-radius:999px;padding:var(--space-xs) var(--space-s)}
 
 /* Footer */
 .mo-footer{padding:28px 0;color:#6b757f}
@@ -166,7 +161,6 @@ a{color:inherit;text-decoration:none}
   border-radius:var(--space-s);
   background:#fff;
   color:var(--ink);
-  font:inherit;
   outline:none;
   transition:border-color .15s ease, box-shadow .15s ease, background-color .2s ease;
   box-sizing:border-box;
@@ -183,7 +177,6 @@ textarea.mo-input{min-height:140px;resize:vertical}
 
 #mo-ok {
   margin-top: 10px;
-  font-size: 0.9rem;
   color: var(--muted);
 }
 
@@ -236,7 +229,6 @@ textarea.mo-input{min-height:140px;resize:vertical}
 }
 .mission-kicker {
   display: inline-block;
-  font-size: 12px;
   letter-spacing: .12em;
   text-transform: uppercase;
   color: var(--accent);
@@ -247,14 +239,12 @@ textarea.mo-input{min-height:140px;resize:vertical}
   margin-bottom: 10px;
 }
 .mission-title {
-  font-size: clamp(28px, 4.2vw, 44px);
   line-height: 1.1;
   margin: 6px 0 14px;
   letter-spacing: -0.02em;
 }
 .mission-lead {
   color: var(--muted);
-  font-size: clamp(16px, 1.6vw, 18px);
   line-height: 1.6;
   margin: 0 0 var(--space-m);
 }
@@ -278,7 +268,6 @@ textarea.mo-input{min-height:140px;resize:vertical}
   background: rgba(255,255,255,.02);
   line-height: 1.5;
   color: var(--text);
-  font-size: 1rem;
 }
 .mission-list li .check {
   width: 22px;
@@ -358,63 +347,31 @@ textarea.mo-input{min-height:140px;resize:vertical}
     aspect-ratio: 16 / 10;
   }
 }
-/* Применяем Inter ко всем элементам */
-html, body, button, input, select, textarea {
-  font-family: 'Inter', system-ui, Arial, sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  text-rendering: optimizeLegibility;
-}
-/* === Базовые настройки шрифтов === */
-html {
-  font-size: 16px; /* Базовый размер: 16px = 1rem */
-}
-
 body, button, input, select, textarea {
-  font-family: 'Inter', system-ui, Arial, sans-serif;
-  font-size: 1rem; /* 1rem = 16px */
   line-height: 1.6;
   color: var(--ink);
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  text-rendering: optimizeLegibility;
 }
 
 /* === Заголовки === */
 h1 {
-  font-size: clamp(28px, 4vw, 48px);
   line-height: 1.2;
-  font-weight: 800;
 }
 
 h2 {
-  font-size: clamp(22px, 3vw, 34px);
   line-height: 1.3;
-  font-weight: 700;
 }
 
 h3 {
-  font-size: clamp(18px, 2.4vw, 24px);
   line-height: 1.3;
-  font-weight: 600;
-}
-
-/* === Текст кнопок и акцентов === */
-.mo-btn,
-.mo-pill {
-  font-size: 0.95rem; /* около 15px */
-  font-weight: 600;
 }
 
 /* === Абзацы и стандартный текст === */
 p, li {
-  font-size: 1rem;
   line-height: 1.6;
 }
 
 /* === Мелкий текст, например для muted === */
 .mo-muted {
-  font-size: 0.9rem; /* около 14px */
   color: var(--muted);
 }
 /* ==== Компактные вертикальные отступы секций (адаптивно) ==== */


### PR DESCRIPTION
## Summary
- strip all font family, size, weight and smoothing properties from style.css
- remove font-related comments to leave only color and spacing rules

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6220f80a8832ca1249afa42bd198a