### PR TITLE
Switch Services section to masonry layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,7 +132,7 @@
 <section id="services" class="mo-section mo-reveal" aria-labelledby="services-title">
   <div class="mo-wrap">
     <h2 id="services-title">Services</h2>
-    <div class="mo-grid mo-grid-3">
+    <div class="services-masonry">
 
       <!-- Service 1 -->
       <article class="mo-card mo-service mo-reveal">

--- a/style.css
+++ b/style.css
@@ -39,6 +39,8 @@ a{color:inherit;text-decoration:none}
 .mo-card-pad{padding:var(--space-m)}
 .mo-grid{display:grid;gap:var(--grid-gap)}
 .mo-grid-3{grid-template-columns:repeat(3,1fr)}
+.services-masonry{column-count:3;column-gap:var(--grid-gap)}
+.services-masonry .mo-service{break-inside:avoid}
 
 /* Nav */
 .mo-nav{position:sticky;top:0;backdrop-filter:blur(10px);background:rgba(255,255,255,.65);border-bottom:1px solid var(--line);z-index:20;display:flex;align-items:center;justify-content:space-between}


### PR DESCRIPTION
## Summary
- Replace Services grid container with `services-masonry`
- Add masonry layout styles and avoid `mo-grid-3` in Services section

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b62fce4ee4832cba6b9ae563a9b334