### PR TITLE
Adjust service card rotations

### DIFF
--- a/style.css
+++ b/style.css
@@ -451,12 +451,29 @@ input, textarea, select, button { font: inherit; }
     background-color .35s,
     box-shadow .3s ease-out;
 }
+#services .mo-service:nth-of-type(2){
+  transform: rotateZ(-1deg) translateY(-10px);
+}
+#services .mo-service:nth-of-type(3),
+#services .mo-service:nth-of-type(5){
+  transform: rotateZ(1deg);
+}
 @media (hover:hover) and (pointer:fine) {
   #services .mo-service:hover,
   #services .mo-service:focus-within{
     transform: scale(1.02) rotateZ(1deg);
     background-color: var(--services-bg-hover);
     box-shadow: var(--services-shadow);
+  }
+  #services .mo-service:nth-of-type(2):hover,
+  #services .mo-service:nth-of-type(2):focus-within{
+    transform: scale(1.02) rotateZ(-1deg) translateY(-10px);
+  }
+  #services .mo-service:nth-of-type(3):hover,
+  #services .mo-service:nth-of-type(3):focus-within,
+  #services .mo-service:nth-of-type(5):hover,
+  #services .mo-service:nth-of-type(5):focus-within{
+    transform: scale(1.02) rotateZ(-1deg);
   }
 }
 


### PR DESCRIPTION
## Summary
- Add individual transforms for selected service cards to tweak initial rotation and offset
- Override hover/focus transforms for specific service cards in @media (hover:hover) block

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c15ba4db50832cbbf8aad8b382317b