### PR TITLE
Remove tilt from Sensibilisation & formation card

### DIFF
--- a/style.css
+++ b/style.css
@@ -453,8 +453,8 @@ input, textarea, select, button { font: inherit; }
     box-shadow .3s ease-out;
 }
 #services .mo-service:nth-of-type(2){
-  --tilt: 2deg;
-  transform: rotateZ(var(--tilt)) translateY(-10px);
+  --tilt: 0deg;
+  transform: translateY(-10px);
 }
 #services .mo-service:nth-of-type(3){
   --tilt: -2deg;
@@ -471,7 +471,7 @@ input, textarea, select, button { font: inherit; }
   }
   #services .mo-service:nth-of-type(2):hover,
   #services .mo-service:nth-of-type(2):focus-within{
-    transform: scale(1.02) rotateZ(calc(var(--tilt) * -1)) translateY(-10px);
+    transform: scale(1.02) translateY(-10px);
   }
 }
 


### PR DESCRIPTION
## Summary
- Stop rotating the "Sensibilisation & formation" service card so it displays straight

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1608c8ab0832cb3319e3508e18973