### PR TITLE
feat: add contact mail helper

### DIFF
--- a/app.js
+++ b/app.js
@@ -81,4 +81,22 @@ document.addEventListener('DOMContentLoaded', () => {
     });
     ro.observe(panel);
   });
+  const contactForm = document.querySelector('#contact form');
+  if (contactForm) {
+    contactForm.addEventListener('submit', moSendMail);
+  }
 });
+
+function moSendMail(e) {
+  e.preventDefault();
+  const nom   = document.getElementById('mo-nom').value.trim();
+  const mail  = document.getElementById('mo-email').value.trim();
+  const msg   = document.getElementById('mo-msg').value.trim();
+
+  const subject = encodeURIComponent(`Contact via site – ${nom}`);
+  const body    = encodeURIComponent(`Nom: ${nom}\nEmail: ${mail}\n\n${msg}`);
+  window.location.href = `mailto:contact@ostanin-rse.fr?subject=${subject}&body=${body}`;
+
+  const ok = document.getElementById('mo-ok');
+  if (ok) { ok.textContent = 'Votre client mail va s’ouvrir.'; ok.hidden = false; }
+}

--- a/index.html
+++ b/index.html
@@ -223,7 +223,7 @@
     <div class="mo-grid mo-grid-2">
 
       <!-- Форма -->
-      <form class="mo-card mo-card-pad mo-reveal" onsubmit="moSendMail(event)">
+      <form class="mo-card mo-card-pad mo-reveal">
         <label class="visually-hidden" for="mo-nom">Nom</label>
         <input id="mo-nom" name="nom" placeholder="Nom" required class="mo-input">
 


### PR DESCRIPTION
## Summary
- add `moSendMail` helper to open the user's mail client
- attach submit handler to contact form instead of inline attribute

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c166e10e34832cb719c69754218514