### PR TITLE
Fix mailto line breaks for contact form

### DIFF
--- a/app.js
+++ b/app.js
@@ -96,7 +96,7 @@ function moSendMail(e) {
   const msg   = document.getElementById('mo-msg').value.trim();
 
   const subject = encodeURIComponent(`Contact via site – ${nom}`);
-  const body    = encodeURIComponent(`Nom: ${nom}\nEmail: ${mail}\n\n${msg}`);
+  const body    = encodeURIComponent('Nom: ' + nom + '\nEmail: ' + mail + '\n\n' + msg);
   window.location.href = `mailto:contact@ostanin-rse.fr?subject=${subject}&body=${body}`;
 
   const ok = document.getElementById('mo-ok');


### PR DESCRIPTION
## Summary
- Encode contact form body with real line breaks so mailto links render correctly

## Testing
- `node --check app.js`
- `node - <<'NODE'\nfunction moSendMailMock(nom, mail, msg) {\n  const subject = encodeURIComponent(`Contact via site – ${nom}`);\n  const body    = encodeURIComponent('Nom: ' + nom + '\nEmail: ' + mail + '\n\n' + msg);\n  return `mailto:contact@ostanin-rse.fr?subject=${subject}&body=${body}`;\n}\nconsole.log(moSendMailMock('Alice','alice@example.com','Line1\\nLine2'));\nNODE`

------
https://chatgpt.com/codex/tasks/task_e_68c16bc57998832c9b9b4f9c2b4d40b6