### PR TITLE
Add mailto action to contact form

### DIFF
--- a/index.html
+++ b/index.html
@@ -223,7 +223,7 @@
     <div class="mo-grid mo-grid-2">
 
       <!-- Форма -->
-      <form class="mo-card mo-card-pad mo-reveal">
+        <form class="mo-card mo-card-pad mo-reveal" action="mailto:contact@ostanin-rse.fr" method="post" enctype="text/plain">
         <label class="visually-hidden" for="mo-nom">Nom</label>
         <input id="mo-nom" name="nom" placeholder="Nom" required class="mo-input">
 


### PR DESCRIPTION
## Summary
- enable mailto email fallback for contact form

## Testing
- `python3 - <<'PY'
from html.parser import HTMLParser
class FormParser(HTMLParser):
    def __init__(self):
        super().__init__()
        self.forms=[]
    def handle_starttag(self, tag, attrs):
        if tag=='form':
            self.forms.append(dict(attrs))
parser=FormParser()
with open('index.html') as f:
    parser.feed(f.read())
print(parser.forms)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68c16e2ff568832cb063a2d03b78f99e