### PR TITLE
Remove obsolete contact form and related code

### DIFF
--- a/app.js
+++ b/app.js
@@ -83,22 +83,4 @@ document.addEventListener('DOMContentLoaded', () => {
       ro.observe(panel);
     });
   }
-  const contactForm = document.querySelector('#contact form');
-  if (contactForm) {
-    contactForm.addEventListener('submit', moSendMail);
-  }
 });
-
-function moSendMail(e) {
-  e.preventDefault();
-  const nom   = document.getElementById('mo-nom').value.trim();
-  const mail  = document.getElementById('mo-email').value.trim();
-  const msg   = document.getElementById('mo-msg').value.trim();
-
-  const subject = encodeURIComponent(`Contact via site – ${nom}`);
-  const body    = encodeURIComponent('Nom: ' + nom + '\nEmail: ' + mail + '\n\n' + msg);
-  window.location.href = `mailto:contact@ostanin-rse.fr?subject=${subject}&body=${body}`;
-
-  const ok = document.getElementById('mo-ok');
-  if (ok) { ok.textContent = 'Votre client mail va s’ouvrir.'; ok.hidden = false; }
-}

--- a/index.html
+++ b/index.html
@@ -222,21 +222,6 @@
     <h2 id="contact-title">Contact</h2>
     <div class="mo-grid mo-grid-2">
 
-      <!-- Форма -->
-        <form class="mo-card mo-card-pad mo-reveal" action="mailto:contact@ostanin-rse.fr" method="post" enctype="text/plain">
-        <label class="visually-hidden" for="mo-nom">Nom</label>
-        <input id="mo-nom" name="nom" placeholder="Nom" required class="mo-input">
-
-        <label class="visually-hidden" for="mo-email">E-mail</label>
-        <input id="mo-email" name="email" type="email" placeholder="E-mail" required class="mo-input">
-
-        <label class="visually-hidden" for="mo-msg">Message</label>
-        <textarea id="mo-msg" name="msg" rows="6" placeholder="Votre besoin (périmètre, délais, contraintes)…" required class="mo-input"></textarea>
-
-        <button class="mo-btn" type="submit">Envoyer</button>
-        <p id="mo-ok" class="mo-muted" hidden></p>
-      </form>
-
       <!-- Блок с контактами -->
       <div class="mo-card mo-card-pad mo-reveal">
         <h3>Coordonnées</h3>

--- a/style.css
+++ b/style.css
@@ -116,27 +116,6 @@ a{color:inherit;text-decoration:none}
   grid-template-columns:1fr 1fr;
   gap:var(--space-m);
 }
-.mo-input{
-  display:block;
-  width:100%;
-  padding:var(--space-s) 14px;
-  border:1px solid var(--line);
-  border-radius:var(--space-s);
-  background:#fff;
-  color:var(--ink);
-  outline:none;
-  transition:border-color .15s ease, box-shadow .15s ease, background-color .2s ease;
-  box-sizing:border-box;
-}
-.mo-input::placeholder{color:var(--muted)}
-.mo-input:focus-visible{
-  border-color:var(--accent);
-  box-shadow:0 0 0 3px color-mix(in oklab, var(--accent) 20%, transparent);
-  background:#fff;
-}
-textarea.mo-input{min-height:140px;resize:vertical}
-.mo-card .mo-input{margin-bottom:var(--space-s)}
-.mo-card button.mo-btn{margin-top:6px}
 
 #mo-ok {
   margin-top: 10px;


### PR DESCRIPTION
## Summary
- Drop contact form markup from the contact section, leaving only contact details.
- Remove unused form handling script.
- Clean up CSS by deleting `.mo-input` styles.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c172d29aa8832ca4cf0abfefb0a7c2