### PR TITLE
feat: harmonize color palette

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,6 +1,6 @@
 :root{
   --ink:#0e0e0e; --muted:#5f6b76; --line:#e9edf2;
-  --accent:#5D2DE6; --accent2:#0a6cc2;
+  --accent:#5D2DE6; --accent2:#8369FF;
   --radius:18px; --shadow:0 10px 30px rgba(0,0,0,.10);
   --maxw:1120px;
   --space-xs:8px; --space-s:12px; --space-m:18px; --space-l:24px;
@@ -9,10 +9,10 @@
   --hero-pad-bottom:clamp(24px,5vw,36px);
   --grid-gap:var(--space-s);
   --services-bg: #ffffff;
-  --services-bg-hover: #EBDCF8;
-  --services-shadow: 0 0.25rem 0.5rem #E6CCF5;
-  --services-border: #2D424D;
-  --services-color: #14252E;
+  --services-bg-hover: #F2E9FF;
+  --services-shadow: 0 0.25rem 0.5rem rgba(93,45,230,0.25);
+  --services-border: #3E2AA8;
+  --services-color: #2B1E6B;
   --services-font: "YourFont", sans-serif;
 }
 
@@ -50,7 +50,8 @@ a{color:inherit;text-decoration:none}
 .mo-nav{position:sticky;top:0;backdrop-filter:blur(10px);background:rgba(255,255,255,.65);border-bottom:1px solid var(--line);z-index:20;display:flex;align-items:center;justify-content:space-between}
 .mo-brand{display:flex;gap:var(--space-s);align-items:center}
 .mo-logo{width:36px;height:36px;border-radius:10px;background:
-  radial-gradient(120px 120px at 20% 20%, #9E81F0, #7241FF 60%), linear-gradient(45deg,#6bdcff,#e6d8ff);
+  radial-gradient(120px 120px at 20% 20%, var(--accent2), var(--accent) 60%),
+  linear-gradient(45deg, var(--accent), var(--accent2));
   box-shadow:var(--shadow);animation:mo-float 6s ease-in-out infinite}
 .mo-links a{margin-left:var(--space-m);color:#39424a;opacity:.9;transition:color .2s ease,opacity .2s ease}
 .mo-links a:hover,.mo-links a:focus-visible{color:var(--accent);text-decoration:underline;opacity:1}


### PR DESCRIPTION
## Summary
- unify accent colors for cohesive visual theme
- adjust logo gradient and service colors for consistent palette

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1801baba4832ca17dc9638ca2bcd3