### PR TITLE
Improve service card open state behavior

### DIFF
--- a/style.css
+++ b/style.css
@@ -452,12 +452,14 @@ input, textarea, select, button { font: inherit; }
     transform: none;
   }
   #services .mo-service:hover,
-  #services .mo-service:focus-within {
-    transform: scale(1.02); /* Сохраняем только масштабирование */
+  #services .mo-service:focus-within,
+  #services .mo-service.is-open {
+    transform: scale(1.02); /* Только масштабирование */
   }
   #services .mo-service:nth-of-type(2):hover,
-  #services .mo-service:nth-of-type(2):focus-within {
-    transform: scale(1.02) translateY(-10px); /* Сохраняем подъем для 2-й карточки */
+  #services .mo-service:nth-of-type(2):focus-within,
+  #services .mo-service:nth-of-type(2).is-open {
+    transform: scale(1.02) translateY(-10px); /* Подъем для 2-й карточки */
   }
 }
 
@@ -465,14 +467,22 @@ input, textarea, select, button { font: inherit; }
 @media (hover:hover) and (pointer:fine) {
   #services .mo-service:hover,
   #services .mo-service:focus-within {
-    transform: scale(1.02) rotateZ(calc(var(--tilt) * -1));
+    transform: scale(1.02); /* Выравниваем и масштабируем */
     background-color: var(--services-bg-hover);
     box-shadow: var(--services-shadow);
   }
   #services .mo-service:nth-of-type(2):hover,
   #services .mo-service:nth-of-type(2):focus-within {
-    transform: scale(1.02) translateY(-10px);
+    transform: scale(1.02) translateY(-10px); /* Подъем для 2-й карточки */
   }
+}
+
+/* При открытии панели карточка выравнивается */
+#services .mo-service.is-open {
+  transform: scale(1.02); /* Прямое положение с масштабированием */
+}
+#services .mo-service:nth-of-type(2).is-open {
+  transform: scale(1.02) translateY(-10px); /* Подъем для 2-й карточки */
 }
 
 /* Заголовок-кнопка */


### PR DESCRIPTION
## Summary
- Unify service card hover, focus, and open behavior on mobile with consistent scaling and offset for the second card
- Simplify desktop hover effects to scale cards and apply translation for the second card
- Add explicit styles for open service cards to remain scaled and aligned

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a9626244832c888fb93eb06ad23f