### PR TITLE
Adjust service toggle typography

### DIFF
--- a/style.css
+++ b/style.css
@@ -379,8 +379,8 @@ input, textarea, select, button { font: inherit; }
 
 /* Кнопка внутри h2 наследует типографику заголовка */
 .mo-service h2 .service-toggle{
-  font: inherit;
-  line-height: inherit;
+  font-size: 1rem;
+  line-height: 1.5;
 }
 
 /* === Services — финальный CSS (без равнения высот) === */


### PR DESCRIPTION
## Summary
- Specify explicit font sizing for `.service-toggle` within service headers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ee0e1938832c9ec5067641c927e2