### PR TITLE
refactor: globalize panel height alignment

### DIFF
--- a/app.js
+++ b/app.js
@@ -21,6 +21,21 @@ document.addEventListener('DOMContentLoaded', () => {
     /* ===== 3) Services: аккордеон ===== */
     const toggles = document.querySelectorAll('#services .service-toggle');
 
+    const alignPanelHeights = () => {
+      const openPanels = document.querySelectorAll('#services .service-panel:not([hidden])');
+      if (openPanels.length === 0) return;
+
+      let maxHeight = 0;
+      openPanels.forEach(panel => {
+        panel.style.maxHeight = '';
+        maxHeight = Math.max(maxHeight, panel.scrollHeight);
+      });
+
+      openPanels.forEach(panel => {
+        panel.style.maxHeight = maxHeight + 'px';
+      });
+    };
+
     toggles.forEach((btn) => {
       if (!btn.hasAttribute('type')) btn.setAttribute('type', 'button');
 
@@ -58,21 +73,6 @@ document.addEventListener('DOMContentLoaded', () => {
           }
         };
         panel.addEventListener('transitionend', onEnd);
-      };
-
-      const alignPanelHeights = () => {
-        const openPanels = document.querySelectorAll('#services .service-panel:not([hidden])');
-        if (openPanels.length === 0) return;
-
-        let maxHeight = 0;
-        openPanels.forEach(panel => {
-          panel.style.maxHeight = '';
-          maxHeight = Math.max(maxHeight, panel.scrollHeight);
-        });
-
-        openPanels.forEach(panel => {
-          panel.style.maxHeight = maxHeight + 'px';
-        });
       };
 
       // Клик: один тап/клик = действие


### PR DESCRIPTION
## Summary
- move alignPanelHeights outside the toggle loop for reuse
- ensure open/close functions call shared alignPanelHeights

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ff9008b4832ca8084b30ba109223