### PR TITLE
style: adjust spacing for services heading

### DIFF
--- a/style.css
+++ b/style.css
@@ -371,6 +371,9 @@ input, textarea, select, button { font: inherit; }
   line-height: 1.15;
   margin: 0 0 var(--space-s);
 }
+#services h2{
+  margin-bottom: var(--space-m);
+}
 
 /* 2) Заголовки карточек услуг */
 .mo-service h2{


### PR DESCRIPTION
## Summary
- add bottom margin to Services section heading for clearer separation from service cards

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c20ddf7044832cae31236f81ff9b64